### PR TITLE
Fix invalid use of `def` to define a function

### DIFF
--- a/source/section/1.2.1.html.md
+++ b/source/section/1.2.1.html.md
@@ -200,10 +200,10 @@ What are the values of the following expressions?
 Consider the following procedures, where A is the procedure defined above:
 
 ```clojure
-(def (f n) (A 0 n))
-(def (g n) (A 1 n))
-(def (h n) (A 2 n))
-(def (k n) (* 5 n n))
+(defn f [n] (A 0 n))
+(defn g [n] (A 1 n))
+(defn h [n] (A 2 n))
+(defn k [n] (* 5 n n))
 ```
 
 Give concise mathematical definitions for the functions computed by


### PR DESCRIPTION
This looks like a spot where an automatic `define => def` translation wasn't fixed.